### PR TITLE
fix typo in `useReducedMotion` code sample

### DIFF
--- a/src/utils/use-reduced-motion.ts
+++ b/src/utils/use-reduced-motion.ts
@@ -14,7 +14,7 @@ import { MotionContext } from "../motion/context/MotionContext"
  * It will actively respond to changes and re-render your components with the latest setting.
  *
  * ```jsx
- * export function Sidebar({ isOpem }) {
+ * export function Sidebar({ isOpen }) {
  *   const shouldReduceMotion = useReducedMotion()
  *   const closedX = shouldReduceMotion ? 0 : "-100%"
  *


### PR DESCRIPTION
https://www.framer.com/api/motion/utilities/#usereducedmotion

![image](https://user-images.githubusercontent.com/203725/78013046-c1fa0580-72fa-11ea-8b98-32409ef8e1d5.png)
